### PR TITLE
Externalize oracle datasource, username and password 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,40 @@ Furthermore the
 
 * CONFIG_LOCATION: ora2pg config file location (inside the container) 
 * OUTPUT_LOCATION: output directory of dump (inside the container) 
+* ORA_HOST: Oracle datasource; the same as `ORACLE_DSN` in ora2pg.conf; if no value provided, ORACLE_DSN will be used.
+* ORA_USER: Oracle user; the same as `ORACLE_USER` in ora2pg.conf; if no value provided, ORACLE_USER will be used.
+* ORA_PWD: Oracle password; the same as `ORACLE_PWD` in ora2pg.conf; if no value provided, ORACLE_PWD will be used.
 
 can be passed via environment variables:
-```
+```shell script
 docker run  \
     --name ora2pg \
     -e CONFIG_LOCATION=/config/myconfigfile.conf  \
     -e OUTPUT_LOCATION=/data/myfolder  \
+    -e ORA_HOST=dbi:Oracle:host=mydb.mydom.fr;sid=SIDNAME;port=1521  \
+    -e ORA_USER=system  \
+    -e ORA_PWD=secret  \
     -it \
     -v /path/to/local/config:/config \
     -v /path/to/local/data:/data \
     georgmoser/ora2pg 
 ```
+or with a docker-compose:
+
+```yaml
+version: '3.3'
+services:
+  ora2pg:
+    container_name: ora2pg
+    environment:
+      - CONFIG_LOCATION: "/config/myconfigfile.conf"
+      - OUTPUT_LOCATION: "/data/myfolder"
+      - ORA_HOST: "dbi:Oracle:host=mydb.mydom.fr;sid=SIDNAME;port=1521"
+      - ORA_USER: "system"
+      - ORA_PWD: "secret"
+    volumes:
+      - '/path/to/local/config:/config'
+      - '/path/to/local/data:/data'
+    image: georgmoser/ora2pg
+```
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+
 function check_env {
     if [ -z "$CONFIG_LOCATION" ]; then
         echo "INFO: No CONFIG_LOCATION variable provided. Using default '/config/ora2pg.conf'"
@@ -15,6 +16,32 @@ function check_env {
         echo "INFO: OUTPUT_LOCATION variable detected: '$OUTPUT_LOCATION'"
         mkdir -p ${OUTPUT_LOCATION}
     fi
+
+    ORA_HOST_FLAG=""
+    if [ -z "$ORA_HOST" ]; then
+        echo "INFO: No ORA_HOST variable provided. Using value of 'ORACLE_DSN' from '$CONFIG_LOCATION'"
+    else
+        echo "INFO: ORA_HOST_FLAG variable detected: '$ORA_HOST'"
+        ORA_HOST_FLAG=" --source $ORA_HOST "
+    fi
+
+    ORA_USER_FLAG=""
+    if [ -z "$ORA_USER" ]; then
+        echo "INFO: No ORA_USER variable provided. Using value of 'ORACLE_USER' from  '$CONFIG_LOCATION'"
+    else
+        echo "INFO: ORA_USER variable detected: '$ORA_USER'"
+        ORA_USER_FLAG=" --user $ORA_USER "
+    fi
+
+    ORA_PWD_FLAG=""
+    ORA_PWD_FLAG_MASKED=""
+    if [ -z "$ORA_PWD" ]; then
+        echo "INFO: No ORA_PWD variable provided. Using value of 'ORACLE_PWD' from  '$CONFIG_LOCATION'"
+    else
+        echo "INFO: ORA_PWD variable detected: '*******'"
+        ORA_PWD_FLAG=" --password $ORA_PWD "
+        ORA_PWD_FLAG_MASKED=" --password ******* "
+    fi
 }
 
 if [ "$1" = 'ora2pg' ]; then
@@ -22,8 +49,8 @@ if [ "$1" = 'ora2pg' ]; then
     check_env
 
     if [ -z "$2" ]; then
-        echo "INFO: no args provided. Using default: '--debug -c $CONFIG_LOCATION --basedir $OUTPUT_LOCATION'"
-        ora2pg --debug -c ${CONFIG_LOCATION} --basedir ${OUTPUT_LOCATION}
+        echo "INFO: no args provided. Using default: '--debug -c $CONFIG_LOCATION --basedir $OUTPUT_LOCATION ${ORA_HOST_FLAG} ${ORA_USER_FLAG}  ${ORA_PWD_FLAG_MASKED} ' "
+        ora2pg --debug -c ${CONFIG_LOCATION} --basedir ${OUTPUT_LOCATION} ${ORA_HOST_FLAG} ${ORA_USER_FLAG}  ${ORA_PWD_FLAG}
     else
         echo "INFO: executing: '$@'"
         exec "$@"


### PR DESCRIPTION
By doing this we'd be able to provide `ORACLE_DSN`,  `ORACLE_USER`, `ORACLE_PWD` from docker-compose/docker.

```
version: '3.3'
services:
  db_schema:
    volumes:
      - './data:/data'
      - './config/schema:/config'
    container_name: ora2pg-schema-jbek
    image: ora2pg:latest
    environment:
       ORA_HOST: "dbi:Oracle:com.example:1521/sidname"
       ORA_USER: "user"
       ORA_PWD: "secret"
```