### PR TITLE
Set base image to perl:stable-slim-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM perl:slim
+FROM perl:stable-slim-bookworm
 
 ARG ORA2PG_VERSION=25.0
 ARG ORA_VERSION=19.26


### PR DESCRIPTION
Pins base image to debian bookworm because of deprecations in DBD::Oracle

Fixes #25 